### PR TITLE
Remove librex.zzls.xyz from list of librex instances

### DIFF
--- a/data.json
+++ b/data.json
@@ -604,7 +604,6 @@
   },
   "librex": {
     "clearnet": [
-      "https://librex.zzls.xyz",
       "https://librex.me",
       "https://s.dyox.in",
       "https://lx.vern.cc",


### PR DESCRIPTION
LibreX is deprecated/orphaned and I don't host it anymore. Since the list comes from the LibreX i don't really know if this is the intended way to delete a instance.