### PR TITLE
Add Redlib instances

### DIFF
--- a/instances.py
+++ b/instances.py
@@ -347,6 +347,11 @@ def libreddit():
                   {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, True)
 
 
+def redlib():
+    fetchJsonList('redlib', 'https://github.com/redlib-org/redlib-instances/raw/main/instances.json',
+                  {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, True)
+
+
 def teddit():
     fetchJsonList('teddit', 'https://codeberg.org/teddit/teddit/raw/branch/main/instances.json',
                   {'clearnet': 'url', 'tor': 'onion', 'i2p': 'i2p', 'loki': None}, False)
@@ -665,6 +670,7 @@ proxitok()
 send()
 nitter()
 libreddit()
+redlib()
 teddit()
 scribe()
 quetre()


### PR DESCRIPTION
With this change LibRedirect extension shows a list of Redlib instances instead of showing nothing.
![Screenshot_20240322_213137](https://github.com/libredirect/instances/assets/57973356/1c6d669c-7c86-455b-a1df-be2fa5bf9015)
