### PR TITLE
Use JSON source for Tent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 - BiblioReads: [https://github.com/nesaku/BiblioReads/blob/main/instances.json](https://github.com/nesaku/BiblioReads/blob/main/instances.json)
 - Suds: [https://git.vern.cc/cobra/Suds/src/branch/main/instances.json](https://git.vern.cc/cobra/Suds/src/branch/main/instances.json)
 - PokeTube: [https://codeberg.org/Ashley/poketube/src/branch/main/instances.json](https://codeberg.org/Ashley/poketube/src/branch/main/instances.json)
-- Tent: [https://forgejo.sny.sh/sun/Tent#instances](https://forgejo.sny.sh/sun/Tent#instances)
+- Tent: [https://forgejo.sny.sh/sun/Tent/raw/branch/main/instances.json](https://forgejo.sny.sh/sun/Tent/raw/branch/main/instances.json)
 - SafeTwitch: [https://codeberg.org/dragongoose/safetwitch#instances](https://codeberg.org/dragongoose/safetwitch#instances)
 - Proxigram: [https://codeberg.org/ThePenguinDev/Proxigram/wiki/Instances](https://codeberg.org/ThePenguinDev/Proxigram/wiki/Instances)
 - Laboratory: [https://git.vitali64.duckdns.org/utils/laboratory.git/about/#instances](https://git.vitali64.duckdns.org/utils/laboratory.git/about/#instances)

--- a/instances.py
+++ b/instances.py
@@ -591,8 +591,7 @@ def mikuInvidious():
 
 
 def tent():
-    fetchRegexList('tent', 'https://forgejo.sny.sh/sun/Tent/raw/branch/main/README.md',
-                   r"- (https?:\/{2}(?:\S+\.)+[a-zA-Z0-9]*)\/?")
+    fetchJsonList('tent', 'https://forgejo.sny.sh/sun/Tent/raw/branch/main/instances.json', 'url', False)
 
 
 def laboratory():


### PR DESCRIPTION
I added a machine-readable instance list to the Tent repository so that I can make changes to the README without having to worry about breaking Libredirect. This PR updates the script to use that JSON list.