### PR TITLE
Removed lucabased as oudated/non-working and add nitter.net

### DIFF
--- a/data.json
+++ b/data.json
@@ -102,10 +102,10 @@
   "nitter": {
     "clearnet": [
       "https://xcancel.com",
+      "https://nitter.net",
       "https://nitter.privacydev.net",
       "https://nitter.poast.org",
       "https://lightbrd.com",
-      "https://nitter.lucabased.xyz",
       "https://nitter.space",
       "https://nitter.privacyredirect.com"
     ],


### PR DESCRIPTION
Lucasbased is still using 2024.04.07 nitter version, and therefore doesn't work. 
![lucasbased-instance-info](https://github.com/user-attachments/assets/735c63c6-5f62-402f-b1e5-353857a258fd)

Nitter.net is back, as Zedeus resume development.