### PR TITLE
Update wikiless.json

### DIFF
--- a/fixed/wikiless.json
+++ b/fixed/wikiless.json
@@ -1,30 +1,21 @@
 {
     "clearnet": [
         "https://wiki.froth.zone",
-        "https://wikiless.esmailelbob.xyz",
         "https://wikiless.northboot.xyz",
         "https://wikiless.tiekoetter.com",
         "https://wl.vern.cc",
         "https://wikiless.rawbit.ninja",
-        "https://wikiless.whateveritworks.org",
         "https://wikiless.funami.tech",
         "https://wiki.adminforge.de",
-        "https://wikiless.datura.network",
         "https://wiki.owo.si",
-        "https://wikiless.ftw.lol",
-        "https://wl.ftw.lol",
         "https://w.sneed.network",
         "https://wikiless.r4fo.com",
         "https://wiki.seitan-ayoub.lol"
     ],
     "tor": [
-        "http://wikiless.esmail5pdn24shtvieloeedh7ehz3nrwcdivnfhfcedl7gf4kwddhkqd.onion",
         "http://ybgg2evrcdz37y2qes23ff3wjqjdn33tthgoagi76vhxytu4mpxiz5qd.onion",
-        "http://c2pesewpalbi6lbfc5hf53q4g3ovnxe4s7tfa6k2aqkf7jd7a7dlz5ad.onion",
-        "http://wl.vernccvbvyi5qhfzyqengccj7lkove6bjot2xhh5kajhwvidqafczrad.onion",
         "http://tdx37ew3oke5rxn3yi5r5665ka7ozvehnd4xmnjxxdvqorias2nyl4qd.onion",
         "http://wiki.pk47sgwhncn5cgidm7bofngmh7lc7ukjdpk5bjwfemmyp27ovl25ikyd.onion",
-        "http://w.sneed4fmhevap3ci4xhf4wgkf72lwk275lcgomnfgwniwmqvaxyluuid.onion"
     ],
     "i2p": [
         "http://wikiless.i2p",


### PR DESCRIPTION
https://wikiless.esmailelbob.xyz: all public instances are gone
https://wikiless.whateveritworks.org: no DNS record
https://wikiless.datura.network: no more clearnet services
https://wikiless.ftw.lol: domain is expired redirects to GoDaddy