### PR TITLE
Fix Piped instances fetch URL

### DIFF
--- a/services/youtube.py
+++ b/services/youtube.py
@@ -42,7 +42,7 @@ def piped(mightyList):
         _list['i2p'] = []
         _list['loki'] = []
         r = requests.get(
-            'https://raw.githubusercontent.com/wiki/TeamPiped/Piped/Instances.md')
+            'https://raw.githubusercontent.com/TeamPiped/documentation/main/content/docs/public-instances/index.md')
 
         tmp = re.findall(
             r' \| (https:\/{2}(?:[^\s\/]+\.)+[a-zA-Z]+) \| ', r.text)


### PR DESCRIPTION
- Removed outdated URL to Piped instances in `services/youtube.py` and replaced with active URL.
- Executed `main.py` locally, and it successfully pulled instances from new, correct URL.

Fixes #49

@IkelAtomig - Sorry for the delay... The holiday season made life busy. :stuck_out_tongue_winking_eye: